### PR TITLE
Websocket Implementation for Multi-player Availability

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -19,5 +19,7 @@ functions:
       - http:
           path: guess_color
           method: get
+  socket:
+    handler: socket.handle_socket
 plugins:
   - serverless-python-requirements

--- a/api/socket.py
+++ b/api/socket.py
@@ -1,0 +1,91 @@
+import json
+import boto3
+
+ENDPOINT = "https://45dl55ctc3.execute-api.us-east-1.amazonaws.com/production/"
+TABLE_NAME = "fox"
+
+# (Key: Value) = (team_name: [connection_id])
+TEAMS = {}
+
+
+def handle_socket(event, _):
+
+    table = boto3.resource('dynamodb').Table(TABLE_NAME)
+
+    route_key = event.get('requestContext', {}).get('routeKey')
+    connection_id = event.get('requestContext', {}).get('connectionId')
+    team_name = event.get('queryStringParameters', {
+                          "team_name": "love"}).get('team_name')
+    client = boto3.client('apigatewaymanagementapi', endpoint_url=ENDPOINT)
+
+    if route_key is None or connection_id is None:
+        return {'statusCode': 400}
+
+    if route_key == "$connect":
+        handle_connect(team_name, connection_id, client, table)
+
+    elif route_key == "$disconnect":
+        handle_disconnect(team_name, connection_id, table)
+
+    elif route_key == "send_team":
+        handle_send_team(team_name, connection_id,
+                         client, json.loads(event["body"]), table)
+
+    return {
+        'statusCode': 200
+    }
+
+
+def handle_connect(team_name, connection_id, client, table):
+
+    res = table.get_item(Key={'team_name': team_name})
+
+    # update the team members
+    if 'Item' in res:
+        members = res['Item']['members'] + [connection_id]
+        table.update_item(
+            Key={'team_name': team_name},
+            UpdateExpression='SET members = :val1',
+            ExpressionAttributeValues={
+                ':val1': members
+            }
+        )
+
+        for conn_id in members:
+            if conn_id != connection_id:
+                client.post_to_connection(
+                    Data=f"new player joined the game", ConnectionId=conn_id)
+
+    # create new members list
+    else:
+        table.put_item(Item={'team_name': team_name,
+                       "members": [connection_id]})
+
+
+def handle_disconnect(team_name, connection_id, table):
+
+    res = table.get_item(Key={'team_name': team_name})
+    members = res['Item']['members']
+
+    if len(members) != 1:
+        table.update_item(
+            Key={'team_name': team_name},
+            UpdateExpression='SET members = :val1',
+            ExpressionAttributeValues={
+                ':val1': list(filter(lambda id: id != connection_id, members))
+            }
+        )
+    else:
+        table.delete_item(
+            Key={'team_name': team_name}
+        )
+
+
+def handle_send_team(team_name, connection_id, client, body, table):
+    res = table.get_item(Key={'team_name': team_name})
+    members = res['Item']['members']
+
+    for conn_id in members:
+        if conn_id != connection_id:
+            client.post_to_connection(
+                Data=json.dumps({"guess": body["guess"], "response": body["response"]}), ConnectionId=conn_id)

--- a/api/socket.py
+++ b/api/socket.py
@@ -51,11 +51,6 @@ def handle_connect(team_name, connection_id, client, table):
             }
         )
 
-        for conn_id in members:
-            if conn_id != connection_id:
-                client.post_to_connection(
-                    Data=f"new player joined the game", ConnectionId=conn_id)
-
     # create new members list
     else:
         table.put_item(Item={'team_name': team_name,

--- a/web/components/guessForm.tsx
+++ b/web/components/guessForm.tsx
@@ -55,6 +55,7 @@ export const GuessForm: FC<GuessFormProps> = ({
               ...guesses,
             ]);
 
+            // Check if socket connection is established and act accordingly
             if (isConnected) {
               onSendResponse(values.guess, response.data);
             }

--- a/web/components/guessForm.tsx
+++ b/web/components/guessForm.tsx
@@ -18,9 +18,16 @@ import { guessResult } from "../types";
 interface GuessFormProps {
   guesses: Array<guessResult>;
   setGuesses: Dispatch<React.SetStateAction<Array<guessResult>>>;
+  isConnected: boolean;
+  onSendResponse: any;
 }
 
-export const GuessForm: FC<GuessFormProps> = ({ guesses, setGuesses }) => {
+export const GuessForm: FC<GuessFormProps> = ({
+  guesses,
+  setGuesses,
+  isConnected,
+  onSendResponse,
+}) => {
   const validateName = (value: string) => {
     let re = /[0-9A-Fa-f]{6}/g;
     let error;
@@ -47,6 +54,10 @@ export const GuessForm: FC<GuessFormProps> = ({ guesses, setGuesses }) => {
               { guess: values.guess, response: response.data },
               ...guesses,
             ]);
+
+            if (isConnected) {
+              onSendResponse(values.guess, response.data);
+            }
           })
           .catch(function (error) {
             console.log(error);

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -29,13 +29,11 @@ const Home: NextPage = () => {
       socket.current.addEventListener("open", onSocketOpen);
       socket.current.addEventListener("close", onSocketClose);
       socket.current.addEventListener("message", (event) => {
-        if (!event.data.startsWith("new")) {
-          var response = JSON.parse(event.data);
-          setGuesses((guesses) => [
-            { guess: response.guess, response: response.response },
-            ...guesses,
-          ]);
-        }
+        var response = JSON.parse(event.data);
+        setGuesses((guesses) => [
+          { guess: response.guess, response: response.response },
+          ...guesses,
+        ]);
       });
     }
   }, [guesses, team]);

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@chakra-ui/react";
+import { Button, Flex, Heading, Input, Spacer } from "@chakra-ui/react";
 import type { NextPage } from "next";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -10,8 +10,9 @@ const URL = "wss://45dl55ctc3.execute-api.us-east-1.amazonaws.com/production/";
 
 const Home: NextPage = () => {
   const [guesses, setGuesses] = useState<Array<guessResult>>([]);
+  const [isConnected, setIsConnected] = useState<boolean>(false);
+  const [team, setTeam] = useState<string>("");
 
-  const [isConnected, setIsConnected] = useState(false);
   const socket = useRef<WebSocket | null>(null);
 
   const onSocketOpen = useCallback(() => {
@@ -24,7 +25,7 @@ const Home: NextPage = () => {
 
   const onConnect = useCallback(() => {
     if (!socket.current || socket.current?.readyState == WebSocket.OPEN) {
-      socket.current = new WebSocket(URL + "?team_name=love");
+      socket.current = new WebSocket(URL + `?team_name=${team}`);
       socket.current.addEventListener("open", onSocketOpen);
       socket.current.addEventListener("close", onSocketClose);
       socket.current.addEventListener("message", (event) => {
@@ -37,7 +38,7 @@ const Home: NextPage = () => {
         }
       });
     }
-  }, [guesses]);
+  }, [guesses, team]);
 
   const onDisconnect = useCallback(() => {
     if (isConnected) {
@@ -55,10 +56,18 @@ const Home: NextPage = () => {
     );
   }, []);
 
+  const handleTeamNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    setTeam(e.target.value);
+  };
+
   return (
     <div>
       {!isConnected ? (
-        <Button onClick={onConnect}>Connect</Button>
+        <Flex>
+          <Input onChange={handleTeamNameChange} />
+          <Button onClick={onConnect}>Join</Button>
+        </Flex>
       ) : (
         <Button onClick={onDisconnect}>Disconnect</Button>
       )}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,15 +1,47 @@
+import { Button } from "@chakra-ui/react";
 import type { NextPage } from "next";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { GuessForm } from "../components/guessForm";
 import { GuessTable } from "../components/guessTable";
 import { guessResult } from "../types";
 
+const URL = "wss://45dl55ctc3.execute-api.us-east-1.amazonaws.com/production/";
+
 const Home: NextPage = () => {
   const [guesses, setGuesses] = useState<Array<guessResult>>([]);
 
+  const [isConnected, setIsConnected] = useState(false);
+  const socket = useRef<WebSocket | null>(null);
+
+  const onConnect = useCallback(() => {
+    if (!socket.current || socket.current?.readyState == WebSocket.OPEN) {
+      socket.current = new WebSocket(URL + "?team_name=love");
+      socket.current.addEventListener("message", (event) => {
+        console.log(event.data);
+      });
+    }
+    setIsConnected(true);
+  }, []);
+
+  const onDisconnect = useCallback(() => {
+    socket.current?.close();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      socket.current?.close();
+      setIsConnected(false);
+    };
+  }, []);
+
   return (
     <div>
+      {isConnected ? (
+        <Button onClick={onConnect}>Connect</Button>
+      ) : (
+        <Button onClick={onDisconnect}>Disconnect</Button>
+      )}
       <GuessForm guesses={guesses} setGuesses={setGuesses} />
 
       <GuessTable guesses={guesses} />


### PR DESCRIPTION
### Summary

This PR brings the functionality of multi-player. Using websockets we can finally play this game in a multi-player behavior. Here are few changes to note.

- New lambda function **socket** was created
- Two dynamoDB was created. Table names are **fox-connections** and **fox-teams**. First table **fox-connections** keep a key value of the connection id and the value as team name. It is simply being used as a reference for the team name. The second table **fox-teams** have a key value as team name and value as a _list of connections_. We will be using this table for referencing all players in the team.
- With the web socket connection, Frontend will be able to connect to a team with a user-defined name. Players with the same team name will be sharing updates for guesses.

### Testing

First, we have to test our websocket connections. First install `wscat`. 
`nom install -g wscat`

Then to start a connection, we can run:
`wscat -c "wss://45dl55ctc3.execute-api.us-east-1.amazonaws.com/production/?team_name=<team_name>`

Run another connection on another terminal with the same team_name. Then in one of the terminal try running something like:
`{"action": "send_team", "guess":"FFFFFF", "response":"you got it!", "team_name":"test2"}`. 

You should see a response from the other connection.

Also, we want to test if it works from web. We can simply test this by playing in two different terminals. Verify if two players joining with same team name and guessing works as expected.